### PR TITLE
`.shift()` works now

### DIFF
--- a/lru.js
+++ b/lru.js
@@ -105,7 +105,7 @@ LRUCache.prototype.remove_entry = function(entry) {
 LRUCache.prototype.get = function(key, returnEntry) {
   // First, find our cache entry
   var entry = this._keymap[key];
-  if (entry === undefined) return; // Not cached. Sorry.
+  if (entry === void 0) return; // Not cached. Sorry.
   // As <key> was found in the cache, register it as being requested recently
   if (entry === this.tail) {
     // Already the most recenlty used entry, so no need to update the list
@@ -122,7 +122,7 @@ LRUCache.prototype.get = function(key, returnEntry) {
   }
   if (entry.older)
     entry.older.newer = entry.newer; // C. --> E
-  entry.newer = undefined; // D --x
+  entry.newer = void 0; // D --x
   entry.older = this.tail; // D. --> E
   if (this.tail)
     this.tail.newer = entry; // E. <-- D
@@ -177,7 +177,7 @@ LRUCache.prototype.entry_value = function(entry) {
 /** Removes all entries */
 LRUCache.prototype.removeAll = function() {
   // This should be safe, as we never expose strong refrences to the outside
-  this.head = this.tail = undefined;
+  this.head = this.tail = void 0;
   this.size = 0;
   this._keymap = {};
 };
@@ -206,7 +206,7 @@ if (typeof Object.keys === 'function') {
  */
 LRUCache.prototype.forEach = function(fun, context, desc) {
   var entry;
-  if (context === true) { desc = true; context = undefined; }
+  if (context === true) { desc = true; context = void 0; }
   else if (typeof context !== 'object') context = this;
   if (desc) {
     entry = this.tail;

--- a/test.js
+++ b/test.js
@@ -47,4 +47,25 @@ to_remove.remove('john');
 assert.equal(to_remove.size, 0);
 assert.equal(to_remove.head, undefined);
 assert.equal(to_remove.tail, undefined);
+
+
+//test shift
+var s = new LRUCache(4);
+assert.equal(s.size, 0);
+s.put('a', 1)
+s.put('b', 2)
+s.put('c', 3)
+assert.equal(s.size, 3);
+var c = s.shift();
+assert(c.key, 'a');
+assert(c.value, 1);
+c = s.shift();
+assert(c.key, 'b');
+assert(c.value, 2);
+c = s.shift();
+assert(c.key, 'c');
+assert(c.value, 3);
+s.forEach(function () { assert(false); }, true);
+assert.equal(s.size, 0);
+
 // If we made it down here, all tests passed. Neat.


### PR DESCRIPTION
There was a bug in `.shift()` not updating metadata correctly.  Added check for bug to `test.js` and fixed it by reusing the `remove` method.