### PR TITLE
Fix putting a new item onto a full LRUCache

### DIFF
--- a/lru.js
+++ b/lru.js
@@ -43,12 +43,10 @@ LRUCache.prototype.put = function(key, value) {
   }
   // add new entry to the end of the linked list -- it's now the freshest entry.
   this.tail = entry;
-  if (this.size === this.limit) {
+  this.size++;
+  if (this.size > this.limit) {
     // we hit the limit -- remove the head
     return this.shift();
-  } else {
-    // increase the size counter
-    this.size++;
   }
 };
 

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ c.put('john', 26);
 c.put('angela', 24);
 c.put('bob', 48);
 assert.equal(c.toString(), 'adam:29 < john:26 < angela:24 < bob:48');
+assert.equal(c.size, 4);
 
 assert.equal(c.get('adam'), 29);
 assert.equal(c.get('john'), 26);
@@ -22,6 +23,7 @@ assert.equal(c.toString(), 'adam:29 < john:26 < bob:48 < angela:24');
 
 c.put('ygwie', 81);
 assert.equal(c.toString(), 'john:26 < bob:48 < angela:24 < ygwie:81');
+assert.equal(c.size, 4);
 assert.equal(c.get('adam'), undefined);
 
 c.set('john', 11);


### PR DESCRIPTION
Current implementation does not behave correctly in the edge case where the `LRUCache` is full and a new item is put on. Shift decrements the size count, so the size was becoming N - 1 instead of staying N like one would expect. This led to weird behavior on subsequent puts since the LRU had N elements but a stored size of N -1.