### PR TITLE
Explain how to import the lru_map package

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ c.toString()        // -> "angela:24 < john:26 < zorro:141"
 
 Just copy the code on lru.js — for minimal functionality, you only need the lines up until the comment that says "Following code is optional".
 
-If you're really into package managers and love having lots of complicated little files in your project, you can use [`npm install lru_map`](https://www.npmjs.com/package/lru_map)
+If you’re really into package managers and love having lots of complicated little files in your project, you can run [`npm install --save lru_map`](https://www.npmjs.com/package/lru_map) and then import the library with `var LRUMap = require('lru_map').LRUMap;` or `import {LRUMap} from 'lru_map';`.
 
 Additionally:
 


### PR DESCRIPTION
And suggest adding `--save` to the `npm install`, because installing packages per-project rather than globally is a best practice, and there is already a simpler installation method listed for people who wouldn’t know that they need to run `npm init`.

It is necessary to explain how to import LRUMap because I at first tried to import it with `import LRUMap from 'lru_map';`. My build then gave only the cryptic error message “`_lru_map2.default` is not a constructor”. It took inspecting the LRUMap source code to figure out that I had to take the `LRUMap` property of what was exported instead of using the exported object directly.