### PR TITLE
Fixed 'forEach' member function problem.

### DIFF
--- a/lru.js
+++ b/lru.js
@@ -224,7 +224,7 @@ class LRUMap {
     return new EntryIterator(this.oldest);
   }
 
-  forEach = function(fun, thisObj) {
+  forEach(fun, thisObj) {
     if (typeof thisObj !== 'object') {
       thisObj = this;
     }


### PR DESCRIPTION
forEach was created as a function, where all the other
member functions are created inline. For whatever reason
this was causing a parsing error when used from webpack
and typescript.

The error as printed was:
"
ERROR in ./src/lru.js 227:10
Module parse failed: Unexpected token (227:10)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   }
|
>   forEach = function(fun, thisObj) {
|     if (typeof thisObj !== 'object') {
|       thisObj = this;
 @ ./src/index.ts 9:12-28
"

This change fixes the problem.