### PR TITLE
Update code in comment – `.newer` → `[NEWER]`

### DIFF
--- a/lru.js
+++ b/lru.js
@@ -193,7 +193,7 @@ class LRUMap {
       entry[OLDER][NEWER] = undefined;
       // link the newer entry to head
       this.newest = entry[OLDER];
-    } else {// if(entry[OLDER] === undefined && entry.newer === undefined) {
+    } else {// if(entry[OLDER] === undefined && entry[NEWER] === undefined) {
       this.oldest = this.newest = undefined;
     }
 


### PR DESCRIPTION
To match the style of `[OLDER]` earlier in the same line, and the use of `[NEWER]` in the many lines above.

A rebased successor to https://github.com/rsms/js-lru/pull/25.