### PR TITLE
feat: Add a `fromJSON` static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ export class LRUMap<K,V> {
   // Returns an object suitable for JSON encoding
   toJSON() : Array<{key :K, value :V}>;
 
+  // Returns an LRU Map from JSON encoding
+  fromJSON(json :Array<{key :K, value :V}>) : LRUMap<K,V>;
+
   // Returns a human-readable text representation
   toString() : string;
 }

--- a/lru.d.ts
+++ b/lru.d.ts
@@ -72,6 +72,9 @@ export class LRUMap<K,V> {
   // Returns an object suitable for JSON encoding
   toJSON() : Array<{key :K, value :V}>;
 
+  // Returns an LRU Map from JSON encoding
+  fromJSON(json :Array<{key :K, value :V}>) : LRUMap<K,V>;
+
   // Returns a human-readable text representation
   toString() : string;
 }

--- a/lru.js
+++ b/lru.js
@@ -245,6 +245,13 @@ class LRUMap {
     return s;
   }
 
+  /** Static method to create an LRUMap instance from a JSON export of a previous LRUMap */
+  static fromJSON(json) {
+    return new LRUMap(json.map(it => {
+      return [it.key, it.value]
+    }))
+  }
+
   /** Returns a String representation */
   toString() {
     var s = '', entry = this.oldest;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lru_map",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Finite key-value map using the Least Recently Used (LRU) algorithm where the most recently used objects are keept in the map while less recently used items are evicted to make room for new ones.",
   "main": "dist/lru.js",
   "types": "lru.d.ts",

--- a/test.js
+++ b/test.js
@@ -287,6 +287,19 @@ toJSON() {
   ]);
 },
 
+fromJSON() {
+  let c = new LRUMap(4, [
+    ['adam',   29],
+    ['john',   26],
+    ['angela', 24],
+    ['bob',    48],
+  ]);
+  let json = c.toJSON();
+  let n = LRUMap.fromJSON(json);
+  assert(n.size == 4);
+  assert.deepEqual(n, c);
+  assert.deepEqual(n.entries(), c.entries());
+},
 
 }; // tests
 


### PR DESCRIPTION
Hi! I recently came across this super-helpful LRUMap library. I came across the need for a `fromJSON` static method and saw issue #32 asking for exactly that. 

Included in this PR:
- Created a static `fromJSON` method
- Added a test
- Updated the README documentation
- Updated the type definition
- Incremented the `z` version

I have NOT yet run `npm run dist` as I think that's something you would do to create a new `npm` version. 

Let me know if this will do the trick! 
