### PR TITLE
fix type definitions

### DIFF
--- a/lru.d.ts
+++ b/lru.d.ts
@@ -61,7 +61,7 @@ export class LRUMap<K,V> {
   values() : Iterator<V>;
 
   // Returns an iterator over all entries, starting with the oldest.
-  entries() : Iterator<[K,V]>;
+  entries() : Iterable<[K,V]>;
 
   // Returns an iterator over all entries, starting with the oldest.
   [Symbol.iterator]() : Iterator<[K,V]>;


### PR DESCRIPTION
`entries()` was typed as returning an iterator, but it actually returns an iterable. (If it returned an iterator, you could call `map.entries().next()`, but that's a runtime error.)

Meanwhile, `keys()` and `values()` do return iterators, which makes their types correct but their behavior a bit inconsistent with `entries()`. I'm not sure if that inconsistency is an issue, so I stuck to just fixing the types in this PR.

If the goal is to match the behavior of the built-in `Map` class, probably `entries()` really should return an iterator. To do that (in a sane way), though, woul be a breaking change.